### PR TITLE
:construction_worker: Build and test on pulls and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Build and Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Restore Cache Local Maven Repository
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}
+          restore-keys: |
+            ${{ runner.os }}-clojure
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Install Clojure Tools
+        uses: DeLaGuardo/setup-clojure@3.5
+        with:
+          cli: 1.11.3.1463
+      - name: Run Tests
+        run: xvfb-run clojure -T:build test
+      - name: Save Cache Local Maven Repository
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}
+


### PR DESCRIPTION
This PR adds a GitHub Actions workflow file for continuous integration. It will run the project's tests for pull requests and pushes to `main`. I tested the caching and it will cache dependencies between runs (at this time ~24MB).

<img width="673" alt="image" src="https://github.com/user-attachments/assets/edf46107-5e13-4530-b217-bf09f8dcba3a">
