### PR TITLE
:bug: Update cache hash to use `deps.edn` file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}
+          key: ${{ runner.os }}-clojure-${{ hashFiles('deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-clojure
       - name: Checkout
@@ -33,5 +33,5 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-clojure-${{ hashFiles('**/project.clj') }}
+          key: ${{ runner.os }}-clojure-${{ hashFiles('deps.edn') }}
 


### PR DESCRIPTION
The cache key was trying to find a `project.clj` file (we have a `deps.edn` file). This fixes that issue; the cache will last as long as the `deps.edn` file doesn't change.

<img width="818" alt="image" src="https://github.com/user-attachments/assets/64b5db75-2c74-4a05-8cad-1e1db46b12b2">
