### PR TITLE
:sparkles: Incorporate `USING` functionality for JOINS

### DIFF
--- a/src/plooney81/nectar/sql.clj
+++ b/src/plooney81/nectar/sql.clj
@@ -1,6 +1,6 @@
 (ns plooney81.nectar.sql
-  (:gen-class)
-  (:require [plooney81.nectar.jsql :as jsql]
+  (:require [honey.sql :as honey]
+            [plooney81.nectar.jsql :as jsql]
             [plooney81.nectar.sql.expression]
             [plooney81.nectar.sql.impl :as impl]
             [plooney81.nectar.sql.select]
@@ -20,24 +20,13 @@
   [raw-sql]
   (impl/jsql->honey-adapter {} (jsql/to-nectar raw-sql)))
 
-(defn -main [& args]
-  (let [query (first args)]
-    (if query
-      (println (ripen query))
-      (println "Please provide a query string as an argument."))))
-
-
-
 (comment
 
-  (ripen
-    "SELECT *
-       FROM people
-      WHERE age > 25
-   ORDER BY age DESC")
-  (defn around-the-horn [sql-string]
-    (-> (ripen sql-string)
-        (honey/format {:inline true :pretty true})))
+  (do
+    (require '[honey.sql :as honey])
+    (defn around-the-horn [sql-string]
+      (-> (ripen sql-string)
+          (honey/format {:inline true :pretty true}))))
 
 
   (-> {:select [:*], :from [:orders], :where [:not-between :amount 100 500]}
@@ -49,8 +38,21 @@
   (-> (str "SELECT * FROM orders WHERE NOT something")
       (ripen)
       #_(around-the-horn))
-  (-> (str "SELECT * FROM employees JOIN departments USING (department_id)")
-      (ripen)
-      #_(around-the-horn))
+  (-> (str "SELECT * FROM employees JOIN departments USING (department_id, employee_id)")
+      #_(ripen)
+      (around-the-horn))
+  (-> {:select [:*]
+       :from   [:employees]
+       :join   [[[:departments [:using :department_id]]]]
+       }
+      (honey/format))
+  (honey/format
+    {:select [:employees.name :departments.name]
+     :from   [:employees]
+     :join   [:departments [:using :department_id]]})
+  (honey/format
+    {:select [:projects.name :assignments.task]
+     :from   [:projects]
+     :join   [:assignments [:using :project_id :employee_id]]})
 
   )

--- a/src/plooney81/nectar/sql/select.clj
+++ b/src/plooney81/nectar/sql/select.clj
@@ -83,7 +83,7 @@
                                    :outer sql/outer-join
                                    sql/join)]
                      (if using
-                       (join-fn honey [[table (apply sql/using using)]])
+                       (join-fn honey table (into [:using] using))
                        (apply join-fn honey table on))))
                  honey))
     honey))

--- a/test/plooney81/select_test.clj
+++ b/test/plooney81/select_test.clj
@@ -1,4 +1,4 @@
-(ns plooney81.nectar-sql-test
+(ns plooney81.select-test
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
             [honey.sql :as honey]
@@ -231,7 +231,17 @@
                                           {:select [:tt.first_column :tt.second_column], :from [[:third_table :tt]]}]}
                              {:select [:ft.first_column :ft.second_column], :from [[:fourth_table :ft]]}]}
                 {:select [:fft.first_column :fft.second_column], :from [[:fifth_table :fft]]}],
-     :order-by [[:fft.first_column :asc]]}))
+     :order-by [[:fft.first_column :asc]]})
+  (test-nectar
+    "Joins with USING statement"
+    (str "SELECT *\n"
+         "FROM employees\n"
+         "INNER JOIN departments AS d USING (d.department_id) "
+         "INNER JOIN compensation AS c USING (c.department_id, c.employee_id)")
+    {:select     [:*]
+     :from       [:employees]
+     :inner-join [[:departments :d] [:using :d.department_id]
+                  [:compensation :c] [:using :c.department_id :c.employee_id]]}))
 
 (deftest mathematical-operations
   (test-nectar


### PR DESCRIPTION
- [X] Changes up how we handle `USING` in joins and adds tests.
- [X] Adjusts the testing namespace