### PR TITLE
:sparkles: Add support for JSON expressions and operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Changed
-- Adds support for `USING` within JOINS
-- Adds repl example to the README
+### Added
+- Support for JSON expression and operators
+- Support for `USING` within JOINS
 - Build and test on pulls and pushes to main
+
+### Changed
+- README to include repl example
 
 ## [1.0.7] - 2024-11-25
 ### Changed

--- a/src/plooney81/nectar/jsql.clj
+++ b/src/plooney81/nectar/jsql.clj
@@ -5,7 +5,7 @@
            (net.sf.jsqlparser.statement.select
              FromItem GroupByElement Join Limit Offset OrderByElement PlainSelect SelectItem SetOperationList WithItem)
            (net.sf.jsqlparser.expression
-             AnalyticExpression CastExpression LongValue NotExpression TrimFunction Function Parenthesis SignedExpression
+             AnalyticExpression CastExpression JsonExpression LongValue NotExpression TrimFunction Function Parenthesis SignedExpression
              WindowDefinition)
            (net.sf.jsqlparser.schema Column)
            ))
@@ -26,9 +26,6 @@
   (-> jsql
       get-select
       get-select))
-
-(defn get-select-body [^PlainSelect jsql]
-  (.getSelectBody jsql))
 
 (defn get-offset [^PlainSelect jsql-select]
   (.getOffset jsql-select))
@@ -187,6 +184,9 @@
   (.getExpression jsql-expr))
 
 (defmethod get-expression NotExpression [jsql-expr]
+  (.getExpression jsql-expr))
+
+(defmethod get-expression JsonExpression [jsql-expr]
   (.getExpression jsql-expr))
 
 (defmethod get-expression :default [jsql-expr]

--- a/src/plooney81/nectar/sql.clj
+++ b/src/plooney81/nectar/sql.clj
@@ -28,9 +28,9 @@
       (-> (ripen sql-string)
           (honey/format {:inline true :pretty true}))))
 
-  (-> (str "SELECT json_column - 'age'")
-      (ripen)
-      #_(around-the-horn))
+  (-> (str "SELECT json_column -> 'name' -> 'another'")
+      #_(ripen)
+      (around-the-horn))
 
   (honey/format {:select [[[:? :json_column "name"]]]} {:inline true :pretty true})
   (honey/format {:select [[:- :json_column "age"]]} {:inline true :pretty true})

--- a/src/plooney81/nectar/sql.clj
+++ b/src/plooney81/nectar/sql.clj
@@ -1,5 +1,6 @@
 (ns plooney81.nectar.sql
   (:require [honey.sql :as honey]
+            [honey.sql.pg-ops]
             [plooney81.nectar.jsql :as jsql]
             [plooney81.nectar.sql.expression]
             [plooney81.nectar.sql.impl :as impl]
@@ -21,38 +22,17 @@
   (impl/jsql->honey-adapter {} (jsql/to-nectar raw-sql)))
 
 (comment
-
   (do
     (require '[honey.sql :as honey])
     (defn around-the-horn [sql-string]
       (-> (ripen sql-string)
           (honey/format {:inline true :pretty true}))))
 
-
-  (-> {:select [:*], :from [:orders], :where [:not-between :amount 100 500]}
-      (honey/format {:inline true}))
-  (-> (str "SELECT *\nFROM orders\nWHERE status IN ('pending', 'shipped', 'delivered') AND status NOT IN ('bloop', 'skoop')")
-      (ripen)
-      #_(around-the-horn)
-      )
-  (-> (str "SELECT * FROM orders WHERE NOT something")
+  (-> (str "SELECT json_column - 'age'")
       (ripen)
       #_(around-the-horn))
-  (-> (str "SELECT * FROM employees JOIN departments USING (department_id, employee_id)")
-      #_(ripen)
-      (around-the-horn))
-  (-> {:select [:*]
-       :from   [:employees]
-       :join   [[[:departments [:using :department_id]]]]
-       }
-      (honey/format))
-  (honey/format
-    {:select [:employees.name :departments.name]
-     :from   [:employees]
-     :join   [:departments [:using :department_id]]})
-  (honey/format
-    {:select [:projects.name :assignments.task]
-     :from   [:projects]
-     :join   [:assignments [:using :project_id :employee_id]]})
+
+  (honey/format {:select [[[:? :json_column "name"]]]} {:inline true :pretty true})
+  (honey/format {:select [[:- :json_column "age"]]} {:inline true :pretty true})
 
   )

--- a/src/plooney81/nectar/sql/select_item.clj
+++ b/src/plooney81/nectar/sql/select_item.clj
@@ -99,7 +99,7 @@
        (catch Exception e
          (throw
            (IllegalArgumentException.
-             (str "Unsupported Select Item type: " (.getClass jsql-expression)))))))
+             (str "Unsupported Select Item type: " (.getClass jsql-expression) "\n" e))))))
 
 (defn select-item->honey [^SelectItem select-item]
   (let [alias (helpers/keywordize-alias select-item)]

--- a/test/plooney81/select_test.clj
+++ b/test/plooney81/select_test.clj
@@ -596,9 +596,11 @@
   (test-nectar
     "Selection operators"
     (str "SELECT json_column -> 'name', "
+         "json_column -> 'name' -> 'another', "
          "CAST('[\"a\", \"b\", \"c\"]' AS JSONB) -> 1, "
          "CAST('{\"name\": \"john\", \"age\": 30}' AS JSONB) ->> 'name'")
     {:select [[[:-> :json_column "name"]]
+              [[:-> :json_column "name" "another"]]
               [[:-> [:cast "[\"a\", \"b\", \"c\"]" :jsonb] 1]]
               [[:->> [:cast "{\"name\": \"john\", \"age\": 30}" :jsonb] "name"]]]})
   (testing


### PR DESCRIPTION
Implemented handling for `JsonExpression` and `JsonOperator` in the `get-expression` and `expression` methods. New utility functions for cleaning up JSON keys and values were introduced. Updated relevant tests to cover new JSON functionalities.