### PR TITLE
:bug: Fixes improper handling of schema names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Fixed
+- Improper handling of schema names
 
 ## [1.0.19] - 2024-11-26
 ### Added

--- a/src/plooney81/nectar/jsql.clj
+++ b/src/plooney81/nectar/jsql.clj
@@ -85,10 +85,19 @@
   (when-let [table (.getTable column)]
     (get-name table)))
 
+(defn get-schema [^FromItem from-item]
+  (.getSchemaName from-item))
+
 (defn convert-from [^FromItem from-item]
-  (if-let [alias (get-alias from-item)]
-    [(keyword (get-name from-item)) (keyword alias)]
-    (keyword (.toString from-item))))
+  (let [alias  (get-alias from-item)
+        schema (get-schema from-item)]
+    (if alias
+      (let [name  (get-name from-item)
+            table (if schema
+                    (str schema "." name)
+                    name)]
+        [(keyword table) (keyword alias)])
+      (keyword (.toString from-item)))))
 
 (defn get-join-items [^PlainSelect jsql-select]
   (.getJoins jsql-select))

--- a/test/plooney81/select_test.clj
+++ b/test/plooney81/select_test.clj
@@ -145,7 +145,13 @@
     (str "SELECT ft.first_column AS my_first\n"
          "FROM first_table AS ft")
     {:select [[:ft.first_column :my_first]]
-     :from   [[:first_table :ft]]}))
+     :from   [[:first_table :ft]]})
+  (test-nectar
+    "Schema with an alias"
+    (str "SELECT ft.first_column AS my_first\n"
+         "FROM some_schema.first_table AS ft")
+    {:select [[:ft.first_column :my_first]]
+     :from   [[:some_schema.first_table :ft]]}))
 
 (deftest grouping-and-ordering
   (test-nectar


### PR DESCRIPTION
Updated the 'convert-from' function to support schema names when converting SQL 'FromItem' objects. This change ensures that tables with schema prefixes are correctly handled and prepended to the table name. Added a relevant test case to verify the functionality of schema parsing with aliases.