### PR TITLE
:sparkles: Add support for parsing and converting SQL INSERT statements

### DIFF
--- a/.idea/clojure-deps.xml
+++ b/.idea/clojure-deps.xml
@@ -4,6 +4,10 @@
     <option name="dirTypeMappings">
       <set>
         <FolderState>
+          <option name="dirUrl" value="file://$PROJECT_DIR$/resources" />
+          <option name="type" value="RESOURCE" />
+        </FolderState>
+        <FolderState>
           <option name="dirUrl" value="file://$PROJECT_DIR$/test" />
           <option name="type" value="TEST_SOURCE" />
         </FolderState>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 - Everything up to date
 
+## [1.0.27] - 2026-04-27
+### Added
+- Support for parsing and converting SQL `INSERT` statements (single row and multi-row `VALUES`)
+
 ## [1.0.24] - 2024-12-09
 ### Fixed
 - Refactor to-nectar type hint
@@ -47,3 +51,4 @@ All notable changes to this project will be documented in this file. This change
 [1.0.19]: https://github.com/plooney81/nectar-sql/compare/1.0.7...1.0.19
 [1.0.22]: https://github.com/plooney81/nectar-sql/compare/1.0.19...1.0.22
 [1.0.24]: https://github.com/plooney81/nectar-sql/compare/1.0.22...1.0.24
+[1.0.27]: https://github.com/plooney81/nectar-sql/compare/1.0.24...1.0.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 - Everything up to date
 
-## [1.0.27] - 2026-04-27
+## [1.0.28] - 2026-04-27
 ### Added
 - Support for parsing and converting SQL `INSERT` statements (single row and multi-row `VALUES`)
 
@@ -51,4 +51,4 @@ All notable changes to this project will be documented in this file. This change
 [1.0.19]: https://github.com/plooney81/nectar-sql/compare/1.0.7...1.0.19
 [1.0.22]: https://github.com/plooney81/nectar-sql/compare/1.0.19...1.0.22
 [1.0.24]: https://github.com/plooney81/nectar-sql/compare/1.0.22...1.0.24
-[1.0.27]: https://github.com/plooney81/nectar-sql/compare/1.0.24...1.0.27
+[1.0.28]: https://github.com/plooney81/nectar-sql/compare/1.0.24...1.0.28

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ hummingbirds. It serves as the raw material for honey.
 
 `nectar-sql`: Converts raw sql strings into honey sql. nectar-sql takes a raw sql string, parses it (using [JSqlParser](JSqlParser)) and converts it into [honeysql](https://github.com/seancorfield/honeysql)
 
-`nectar-sql` is currently a work in progress and, at present, can be expected to handle a wide variety of `SELECT` queries.
+`nectar-sql` is currently a work in progress and, at present, can be expected to handle a wide variety of `SELECT` and `INSERT` queries.
 
 ## Try It from Your REPL
 
@@ -82,8 +82,8 @@ Your library will be deployed to net.clojars.plooney81/nectar-sql on clojars.org
 ## Support
 
 - Scope:
-    - We currently only support `SELECT` functionality
-    - We hope to support `INSERT`, `UPDATE`, `DELETE` in the future
+    - We currently support `SELECT` and `INSERT` functionality
+    - We hope to support `UPDATE` and `DELETE` in the future
 
 - nectar-sql relies heavily on [JSQLParser](JSqlParser)
     - JSQLParser doesn't currently support a few pieces of functionality, like Implicit Casting in Postgres

--- a/src/plooney81/nectar/sql.clj
+++ b/src/plooney81/nectar/sql.clj
@@ -4,10 +4,12 @@
             [plooney81.nectar.jsql :as jsql]
             [plooney81.nectar.sql.expression]
             [plooney81.nectar.sql.impl :as impl]
+            [plooney81.nectar.sql.insert]
             [plooney81.nectar.sql.select]
             [plooney81.nectar.sql.select-item]
             [plooney81.nectar.sql.set-operation])
-  (:import (net.sf.jsqlparser.statement.select Select)))
+  (:import (net.sf.jsqlparser.statement.insert Insert)
+           (net.sf.jsqlparser.statement.select Select)))
 
 (defmethod impl/jsql->honey-adapter :default [_honey jsql]
   (throw (IllegalArgumentException.
@@ -15,6 +17,9 @@
 
 (defmethod impl/jsql->honey-adapter Select [honey jsql]
   (impl/select->honey honey jsql))
+
+(defmethod impl/jsql->honey-adapter Insert [honey jsql]
+  (impl/insert->honey honey jsql))
 
 (defn ripen
   "Process of turning nectar into honey. Accepts a raw-sql string and returns a honeysql map."
@@ -28,11 +33,10 @@
       (-> (ripen sql-string)
           (honey/format {:inline true :pretty true}))))
 
-  (-> (str "SELECT json_column -> 'name' -> 'another'")
-      #_(ripen)
-      (around-the-horn))
+  (around-the-horn "SELECT json_column -> 'name' -> 'another'")
 
-  (honey/format {:select [[[:? :json_column "name"]]]} {:inline true :pretty true})
-  (honey/format {:select [[:- :json_column "age"]]} {:inline true :pretty true})
+  (around-the-horn "INSERT INTO users AS u (id, username, email) VALUES (1, 'john_doe', 'john@example.com')")
+
+  (around-the-horn "INSERT INTO users AS u (id, username, email) VALUES (1, 'john_doe', 'john@example.com'), (2, 'admin', 'admin@example.com')")
 
   )

--- a/src/plooney81/nectar/sql/expression.clj
+++ b/src/plooney81/nectar/sql/expression.clj
@@ -161,8 +161,7 @@
   [v]
   (if (and (string? v) (re-matches #"^'.*'$" v))
     (subs v 1 (dec (count v)))
-    v)
-  )
+    v))
 
 (defn cleanup-key
   "Tries to convert to an int if possible. If not trim-inner-quotes."
@@ -176,7 +175,6 @@
 (impl/register-operator! :->>)
 ;; https://github.com/seancorfield/honeysql/blob/develop/test/honey/sql/pg_ops_test.cljc
 (defmethod impl/expression JsonExpression [^JsonExpression jsql-expr]
-  (def my-jsql jsql-expr)
   (let [expression (impl/expression (jsql/get-expression jsql-expr))
         expression (if (vector? expression) (first expression) expression)
         {:keys [operator exprs]} (->> jsql-expr

--- a/src/plooney81/nectar/sql/impl.clj
+++ b/src/plooney81/nectar/sql/impl.clj
@@ -14,6 +14,12 @@
     (.getClass jsql-select)))
 
 (defmulti
+  insert->honey
+  "Converts jsql-insert objects to honey-sql based on the class"
+  (fn [_honey jsql-insert]
+    (.getClass jsql-insert)))
+
+(defmulti
   expression
   "Converts a jsql expression to an alternative syntax that will ultimately be used to convert to honeysql"
   (fn [jsql-expr]

--- a/src/plooney81/nectar/sql/insert.clj
+++ b/src/plooney81/nectar/sql/insert.clj
@@ -1,0 +1,43 @@
+(ns plooney81.nectar.sql.insert
+  (:require [honey.sql.helpers :as sql]
+            [plooney81.nectar.jsql :as jsql]
+            [plooney81.nectar.sql.helpers :as helpers]
+            [plooney81.nectar.sql.impl :as impl])
+  (:import (net.sf.jsqlparser.statement.insert Insert)))
+
+(defn get-columns [jsql-insert]
+  (when-let [columns (.getColumns jsql-insert)]
+    (->> columns
+         (mapv helpers/convert-column))))
+
+(defn handle-into [honey jsql-insert]
+  (if-let [table (.getTable jsql-insert)]
+    (if-let [columns (get-columns jsql-insert)]
+      (sql/insert-into honey (jsql/convert-table table) columns)
+      (sql/insert-into honey (jsql/convert-table table)))
+    honey))
+
+(defn convert-values [^Insert jsql-insert]
+  (when-let [values (.getValues jsql-insert)]
+    (let [converted-values (->> values
+                                (.getExpressions)
+                                (mapv impl/expression->honey))
+          columns-count    (count (get-columns jsql-insert))]
+      (if (<= (/ columns-count (count converted-values)) 1)
+        [converted-values]
+        converted-values))))
+
+(defn handle-values [honey jsql-insert]
+  (if-let [values (convert-values jsql-insert)]
+    (sql/values honey values)
+    honey))
+
+(defmethod impl/insert->honey Insert [honey ^Insert jsql-insert]
+  (-> honey
+      (handle-into jsql-insert)
+      (handle-values jsql-insert)))
+
+
+(defmethod impl/insert->honey :default [_honey jsql-insert]
+  (throw (IllegalArgumentException.
+           (str "Unsupported Insert type: " (.getClass jsql-insert)))))

--- a/src/plooney81/nectar/sql/select.clj
+++ b/src/plooney81/nectar/sql/select.clj
@@ -52,7 +52,7 @@
 
 (defn convert-from-item [honey jsql-select]
   (if-let [from-item (jsql/get-from-item jsql-select)]
-    (sql/from honey (jsql/convert-from from-item))
+    (sql/from honey (jsql/convert-table from-item))
     honey))
 
 (defn convert-join-items [honey jsql-select]
@@ -63,7 +63,7 @@
                       table                    (jsql/get-join-table join-item)
                       using                    (jsql/get-join-using-columns join-item)
                       on-expressions           (jsql/get-join-on-expressions join-item)
-                      converted-table          (jsql/convert-from table)
+                      converted-table          (jsql/convert-table table)
                       converted-using          (->> using
                                                     (map helpers/convert-column))
                       converted-on-expressions (->> on-expressions

--- a/test/plooney81/insert_test.clj
+++ b/test/plooney81/insert_test.clj
@@ -1,0 +1,18 @@
+(ns plooney81.insert-test
+  (:require [clojure.test :refer :all]
+            [plooney81.test-helpers :as th]))
+
+(deftest simple-inserts
+  (th/test-nectar
+    "simple-insert"
+    (str "INSERT INTO users AS u (id, username, email)\n"
+         "VALUES (1, 'john_doe', 'john@example.com')")
+    {:insert-into [[:users :u] [:id :username :email]]
+     :values      [[1 "john_doe" "john@example.com"]]})
+  (th/test-nectar
+    "multi row insert"
+    (str "INSERT INTO users AS u (id, username, email)\n"
+         "VALUES (1, 'john_doe', 'john@example.com'), (2, 'admin', 'admin@example.com')")
+    {:insert-into [[:users :u] [:id :username :email]]
+     :values      [[1 "john_doe" "john@example.com"] [2 "admin" "admin@example.com"]]})
+  )

--- a/test/plooney81/test_helpers.clj
+++ b/test/plooney81/test_helpers.clj
@@ -1,0 +1,19 @@
+(ns plooney81.test-helpers
+  "Helper functions to be used in other testing namespaces"
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
+            [honey.sql :as honey]
+            [plooney81.nectar.sql :as nsql]))
+
+(defn honey->text [honeysql]
+  (-> (honey/format honeysql {:inline true :pretty true})
+      first
+      str/trim))
+
+(defn test-nectar [description raw-sql expected-honey]
+  (let [nectar (nsql/ripen raw-sql)]
+    (testing description
+      ;; tests that ripen outputs expected-honey
+      (is (= nectar expected-honey))
+      ;; tests that converting the nectar back to raw-sql gets us our original raw-sql
+      (is (= (honey->text nectar) raw-sql)))))


### PR DESCRIPTION
Resolves #8 

This commit introduces functionality to handle SQL INSERT statements, mapping their structure from jsqlparser to HoneySQL. Key changes include new methods for converting tables, columns, and values in INSERT statements, along with updated test cases and modularization of helper functions. This improves parsing flexibility and alignment with the existing SELECT statement handling.

